### PR TITLE
Implement refresh token API

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ disabled_rules:
   - line_length
   - function_body_length
   - type_body_length
+  - file_length
 
 opt_in_rules:
   - anyobject_protocol

--- a/NimbleSurvey.xcodeproj/project.pbxproj
+++ b/NimbleSurvey.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D8C1A328282C0C9C00803A86 /* PlaceholderSurveyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C1A327282C0C9C00803A86 /* PlaceholderSurveyCell.swift */; };
 		D8C1A32A282D460800803A86 /* AccessTokenAuthorizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C1A329282D460800803A86 /* AccessTokenAuthorizable.swift */; };
 		D8C1A32C282D649700803A86 /* MockNimbleSurveyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C1A32B282D649700803A86 /* MockNimbleSurveyClient.swift */; };
+		D8C1A32E282E8C7600803A86 /* Credential.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C1A32D282E8C7600803A86 /* Credential.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,6 +110,7 @@
 		D8C1A327282C0C9C00803A86 /* PlaceholderSurveyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderSurveyCell.swift; sourceTree = "<group>"; };
 		D8C1A329282D460800803A86 /* AccessTokenAuthorizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenAuthorizable.swift; sourceTree = "<group>"; };
 		D8C1A32B282D649700803A86 /* MockNimbleSurveyClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNimbleSurveyClient.swift; sourceTree = "<group>"; };
+		D8C1A32D282E8C7600803A86 /* Credential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credential.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -273,6 +275,7 @@
 				D8492D2D28295C55004F949D /* NimbleSurveyAPIProtocol.swift */,
 				D8492D2F28295C7F004F949D /* NimbleSurveyAPI.swift */,
 				D8492D3128295E70004F949D /* NimbleTargetType.swift */,
+				D8C1A32D282E8C7600803A86 /* Credential.swift */,
 			);
 			path = NimbleSurveyAPI;
 			sourceTree = "<group>";
@@ -611,6 +614,7 @@
 				D8492D142827428D004F949D /* LoginViewModel.swift in Sources */,
 				D8C1A328282C0C9C00803A86 /* PlaceholderSurveyCell.swift in Sources */,
 				D8492D3028295C7F004F949D /* NimbleSurveyAPI.swift in Sources */,
+				D8C1A32E282E8C7600803A86 /* Credential.swift in Sources */,
 				D8492D0728262AE8004F949D /* UIView+Styles.swift in Sources */,
 				D8C1A324282C09CF00803A86 /* UIView+addSubviews.swift in Sources */,
 				D8492D41282980E8004F949D /* main.swift in Sources */,

--- a/NimbleSurvey/App/Login/LoginViewModel.swift
+++ b/NimbleSurvey/App/Login/LoginViewModel.swift
@@ -41,7 +41,7 @@ class LoginViewModel: ViewModelType {
 
         let loginEnabled = formInputs
             .map { email, password in
-                // Naive validation instead using some complex Regex from StackOverflow!
+                // Naive validation instead of using some complex Regex from StackOverflow!
                 return email.contains("@") && !password.isEmpty
             }
             .startWith(false)
@@ -54,7 +54,7 @@ class LoginViewModel: ViewModelType {
                     return .error(LoginError(message: R.string.localizable.login_fail_unknown()))
                 }
 
-                return self.nimbleSurveyClient.login(email: email, password: password)
+                return self.nimbleSurveyClient.authenticate(email: email, password: password)
                     .andThen(.just(.success(true)))
                     .catch { _ in
                         throw LoginError(message: R.string.localizable.login_fail_authen_fail())

--- a/NimbleSurvey/Network/BaseNetworkAPI.swift
+++ b/NimbleSurvey/Network/BaseNetworkAPI.swift
@@ -51,7 +51,7 @@ open class BaseNetworkAPI<Target: TargetType>: NetworkAPIProtocol {
                 name: "Authorization",
                 value: "\(authorizationType.rawValue) \(accessToken)"
             )
-            
+
             if headers == nil {
                 headers = .init([header])
             } else {

--- a/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/Credential.swift
+++ b/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/Credential.swift
@@ -1,0 +1,22 @@
+//
+//  Credential.swift
+//  NimbleSurvey
+//
+//  Created by Doan Le Thieu on 13/05/2022.
+//
+
+import Foundation
+
+struct Credential: Equatable, Codable {
+    let accessToken: String
+    let tokenType: String
+    let refreshToken: String
+    let validUntil: Date
+    
+    init(accessToken: String, tokenType: String, refreshToken: String, validUntil: Date) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.refreshToken = refreshToken
+        self.validUntil = validUntil
+    }
+}

--- a/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/NimbleSurveyAPIProtocol.swift
+++ b/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/NimbleSurveyAPIProtocol.swift
@@ -8,6 +8,7 @@
 import RxSwift
 
 protocol NimbleSurveyAPIProtocol {
-    func login(email: String, password: String, clientId: String, clientSecret: String) -> Completable
+    func login(email: String, password: String, clientId: String, clientSecret: String) -> Single<Credential>
+    func refreshToken(refreshToken: String, clientId: String, clientSecret: String) -> Single<Credential>
     func surveyList(pageNumber: Int, pageSize: Int) -> Single<[Survey]>
 }

--- a/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/NimbleTargetType.swift
+++ b/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/NimbleTargetType.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum NimbleTargetType: TargetType, AccessTokenAuthorizable {
     case login(email: String, password: String, clientId: String, clientSecret: String)
+    case refreshToken(refreshToken: String, clientId: String, clientSecret: String)
     case surveyList(pageNumber: Int, pageSize: Int)
 
     var baseURL: URL {
@@ -19,7 +20,7 @@ enum NimbleTargetType: TargetType, AccessTokenAuthorizable {
 
     var path: String {
         switch self {
-        case .login:
+        case .login, .refreshToken:
             return "/oauth/token"
         case .surveyList:
             return "/surveys"
@@ -28,7 +29,7 @@ enum NimbleTargetType: TargetType, AccessTokenAuthorizable {
 
     var method: HTTPMethod {
         switch self {
-        case .login:
+        case .login, .refreshToken:
             return .post
         case .surveyList:
             return .get
@@ -50,6 +51,14 @@ enum NimbleTargetType: TargetType, AccessTokenAuthorizable {
                 "client_secret": clientSecret
             ]
 
+        case let .refreshToken(refreshToken, clientId, clientSecret):
+            return [
+                "grant_type": "refresh_token",
+                "refresh_token": refreshToken,
+                "client_id": clientId,
+                "client_secret": clientSecret
+            ]
+
         case let .surveyList(pageNumber, pageSize):
             return [
                 "page_number": pageNumber,
@@ -60,7 +69,7 @@ enum NimbleTargetType: TargetType, AccessTokenAuthorizable {
 
     var encoding: ParameterEncoding {
         switch self {
-        case .login:
+        case .login, .refreshToken:
             return JSONEncoding()
         case .surveyList:
             return URLEncoding()
@@ -69,7 +78,7 @@ enum NimbleTargetType: TargetType, AccessTokenAuthorizable {
 
     var authorizationType: AuthorizationType? {
         switch self {
-        case .login:
+        case .login, .refreshToken:
             return nil
         case .surveyList:
             return .bearer

--- a/NimbleSurvey/NimbleSurveyClient/NimbleSurveyClient.swift
+++ b/NimbleSurvey/NimbleSurveyClient/NimbleSurveyClient.swift
@@ -33,13 +33,14 @@ class NimbleSurveyClient: NimbleSurveyClientType {
         self.clientSecret = clientSecret
     }
 
-    func login(email: String, password: String) -> Completable {
+    func authenticate(email: String, password: String) -> Completable {
         return nimbleSurveyAPI.login(
             email: email,
             password: password,
             clientId: clientId,
             clientSecret: clientSecret
         )
+        .asCompletable()
         .catch { _ in
             throw NimbleSurveyError.authenticationFailed
         }

--- a/NimbleSurvey/NimbleSurveyClient/NimbleSurveyClientType.swift
+++ b/NimbleSurvey/NimbleSurveyClient/NimbleSurveyClientType.swift
@@ -8,6 +8,6 @@
 import RxSwift
 
 protocol NimbleSurveyClientType {
-    func login(email: String, password: String) -> Completable
+    func authenticate(email: String, password: String) -> Completable
     func surveyList(pageNumber: Int, pageSize: Int) -> Single<[Survey]>
 }

--- a/NimbleSurveyTests/Login/MockNimbleSurveyClient.swift
+++ b/NimbleSurveyTests/Login/MockNimbleSurveyClient.swift
@@ -9,11 +9,11 @@
 import RxSwift
 
 class MockNimbleSurveyClient: NimbleSurveyClientType {
-    var loginResult: Result<Bool, NimbleSurveyError>?
+    var authenticateResult: Result<Bool, NimbleSurveyError>?
     var surveyListResult: Result<[Survey], NimbleSurveyError>?
 
-    func login(email: String, password: String) -> Completable {
-        switch loginResult {
+    func authenticate(email: String, password: String) -> Completable {
+        switch authenticateResult {
         case .success, .none:
             return .empty()
         case .failure(let error):

--- a/NimbleSurveyTests/NimbleSurveyClient/MockNimbleSurveyAPI.swift
+++ b/NimbleSurveyTests/NimbleSurveyClient/MockNimbleSurveyAPI.swift
@@ -10,15 +10,29 @@ import Foundation
 import RxSwift
 
 class MockNimbleSurveyAPI: NimbleSurveyAPIProtocol {
-    var loginResult: Result<Bool, NimbleSurveyError>?
+    var loginResult: Result<Credential, NimbleSurveyError>?
+    var refreshTokenResult: Result<Credential, NimbleSurveyError>?
     var surveyListResult: Result<[Survey], NimbleSurveyError>?
 
-    func login(email: String, password: String, clientId: String, clientSecret: String) -> Completable {
+    func login(email: String, password: String, clientId: String, clientSecret: String) -> Single<Credential> {
         switch loginResult {
-        case .success, .none:
-            return .empty()
+        case .success(let credential):
+            return .just(credential)
         case .failure(let error):
             return .error(error)
+        case .none:
+            return .error(NimbleSurveyError.authenticationFailed)
+        }
+    }
+
+    func refreshToken(refreshToken: String, clientId: String, clientSecret: String) -> Single<Credential> {
+        switch refreshTokenResult {
+        case .success(let credential):
+            return .just(credential)
+        case .failure(let error):
+            return .error(error)
+        case .none:
+            return .error(NimbleSurveyError.authenticationFailed)
         }
     }
 

--- a/NimbleSurveyTests/NimbleSurveyClient/NimbleSurveyClientTests.swift
+++ b/NimbleSurveyTests/NimbleSurveyClient/NimbleSurveyClientTests.swift
@@ -41,29 +41,37 @@ class NimbleSurveyClientTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Test Login
+    // MARK: - Test authenticate
 
-    func testLoginFail() {
+    func testAuthenticateFail() {
         mockNimbleSurveyAPI.loginResult = .failure(.authenticationFailed)
         nimbleSurveyClient.nimbleSurveyAPI = mockNimbleSurveyAPI
 
-        let result = nimbleSurveyClient.login(email: email, password: password)
+        let result = nimbleSurveyClient.authenticate(email: email, password: password)
             .toBlocking()
             .materialize()
 
         switch result {
         case .completed:
-            XCTFail("Should login fail")
+            XCTFail("Should authenticate fail")
         case let .failed(_, error):
             XCTAssertTrue((error as? NimbleSurvey.NimbleSurveyError) == .authenticationFailed)
         }
     }
 
-    func testLoginSuccess() {
-        mockNimbleSurveyAPI.loginResult = .success(true)
+    func testAuthenticateSuccess() {
+        mockNimbleSurveyAPI.loginResult = .success(
+            Credential(
+                accessToken: "at1234",
+                tokenType: "Bearer",
+                refreshToken: "rt5678",
+                validUntil: Date()
+            )
+        )
+        
         nimbleSurveyClient.nimbleSurveyAPI = mockNimbleSurveyAPI
 
-        let result = nimbleSurveyClient.login(email: email, password: password)
+        let result = nimbleSurveyClient.authenticate(email: email, password: password)
             .toBlocking()
             .materialize()
 
@@ -71,7 +79,7 @@ class NimbleSurveyClientTests: XCTestCase {
         case .completed:
             break
         case .failed:
-            XCTFail("Should login successfully")
+            XCTFail("Should authenticate successfully")
         }
     }
 


### PR DESCRIPTION
- Rename NimbleSurveyClient's `login` to `authenticate`, with return
types of `Credential`
- Implement refresh token on NimbleSurveyAPI