### PR TITLE
[API][Feature][#24] Update parsing JSON API

### DIFF
--- a/NimbleSurvey/Network/BaseNetworkAPI.swift
+++ b/NimbleSurvey/Network/BaseNetworkAPI.swift
@@ -7,6 +7,7 @@
 
 import Alamofire
 import Foundation
+import JSONAPI
 import RxAlamofire
 import RxSwift
 
@@ -91,7 +92,9 @@ open class BaseNetworkAPI<Target: TargetType>: NetworkAPIProtocol {
                 switch error {
                 case is URLError:
                     throw APIError.network
-                case is DecodingError:
+                case is DecodingError, is DocumentDecodingError:
+                    // Include `DocumentDecodingError` which is from a 3rd-party lib
+                    // may be not a good idea!
                     throw APIError.parsing
                 default:
                     throw (error as? APIError) ?? APIError.unknown

--- a/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/NimbleSurveyAPI.swift
+++ b/NimbleSurvey/NimbleSurveyClient/NimbleSurveyAPI/NimbleSurveyAPI.swift
@@ -7,7 +7,16 @@
 
 import Alamofire
 import Foundation
+import JSONAPI
 import RxSwift
+
+// MARK: - Private types support parsing API
+
+private typealias Resource<Description: JSONAPI.ResourceObjectDescription> = JSONAPI.ResourceObject<Description, NoMetadata, NoLinks, String>
+private typealias SingleDocument<Resource: ResourceObjectType> = JSONAPI.Document<SingleResourceBody<Resource>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>
+private typealias BatchDocument<Resource: ResourceObjectType> = JSONAPI.Document<ManyResourceBody<Resource>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>
+
+// MARK: -
 
 class NimbleSurveyAPI: BaseNetworkAPI<NimbleTargetType>, NimbleSurveyAPIProtocol {
     func login(email: String, password: String, clientId: String, clientSecret: String) -> Single<Credentials> {
@@ -18,9 +27,15 @@ class NimbleSurveyAPI: BaseNetworkAPI<NimbleTargetType>, NimbleSurveyAPIProtocol
                 clientId: clientId,
                 clientSecret: clientSecret
             ),
-            type: OAuthResponse.self
+            type: SingleDocument<Resource<TokenResponseDescription>>.self
         )
-        .map { $0.toCredentials() }
+        .map {
+            guard let decoded = $0.body.primaryResource?.value else {
+                throw APIError.parsing
+            }
+
+            return decoded.toCredentials()
+        }
     }
 
     func refreshToken(refreshToken: String, clientId: String, clientSecret: String) -> Single<Credentials> {
@@ -30,9 +45,15 @@ class NimbleSurveyAPI: BaseNetworkAPI<NimbleTargetType>, NimbleSurveyAPIProtocol
                 clientId: clientId,
                 clientSecret: clientSecret
             ),
-            type: OAuthResponse.self
+            type: SingleDocument<Resource<TokenResponseDescription>>.self
         )
-        .map { $0.toCredentials() }
+        .map {
+            guard let decoded = $0.body.primaryResource?.value else {
+                throw APIError.parsing
+            }
+
+            return decoded.toCredentials()
+        }
     }
 
     func surveyList(pageNumber: Int, pageSize: Int) -> Single<[Survey]> {
@@ -41,67 +62,64 @@ class NimbleSurveyAPI: BaseNetworkAPI<NimbleTargetType>, NimbleSurveyAPIProtocol
                 pageNumber: pageNumber,
                 pageSize: pageSize
             ),
-            type: SurveysResponse.self
+            type: BatchDocument<Resource<SurveyResponseDescription>>.self
         )
-        .map { $0.toSurveys() }
-    }
-}
+        .map {
+            guard let decoded = $0.body.primaryResource?.values else {
+                throw APIError.parsing
+            }
 
-// MARK: - API's responses (naming convetion: suffix with `Response`)
-
-private struct OAuthResponse: Decodable {
-    struct Data: Decodable {
-        let attributes: Attributes
-    }
-
-    struct Attributes: Decodable {
-        let accessToken: String
-        let tokenType: String
-        let expiresIn: Double
-        let refreshToken: String
-        let createdAt: Double
-    }
-
-    let data: Data
-
-    // Map to app's object
-    func toCredentials() -> Credentials {
-        let attributes = data.attributes
-
-        return Credentials(
-            accessToken: attributes.accessToken,
-            tokenType: attributes.tokenType,
-            refreshToken: attributes.refreshToken,
-            validUntil: Date(timeIntervalSince1970: attributes.createdAt + attributes.expiresIn)
-        )
-    }
-}
-
-private struct SurveysResponse: Decodable {
-    struct Datum: Decodable {
-        let id: String
-        let attributes: Attributes
-    }
-
-    struct Attributes: Decodable {
-        let title: String
-        let description: String
-        let coverImageUrl: URL?
-    }
-
-    let data: [Datum]
-
-    // Map to app's object
-    func toSurveys() -> [Survey] {
-        return data.map { datum in
-            let attributes = datum.attributes
-
-            return Survey(
-                id: datum.id,
-                title: attributes.title,
-                description: attributes.description,
-                coverImageUrl: attributes.coverImageUrl
-            )
+            return decoded.map { $0.toSurvey() }
         }
+    }
+}
+
+// MARK: - API's response description
+
+private struct TokenResponseDescription: ResourceObjectDescription {
+    typealias Relationships = NoRelationships
+    static let jsonType: String = "token"
+
+    struct Attributes: JSONAPI.Attributes {
+        let accessToken: Attribute<String>
+        let tokenType: Attribute<String>
+        let expiresIn: Attribute<Double>
+        let refreshToken: Attribute<String>
+        let createdAt: Attribute<Double>
+    }
+}
+
+private struct SurveyResponseDescription: ResourceObjectDescription {
+    typealias Relationships = NoRelationships
+    static let jsonType: String = "survey"
+
+    struct Attributes: JSONAPI.Attributes {
+        let title: Attribute<String>
+        let description: Attribute<String>
+        let coverImageUrl: Attribute<URL?>
+    }
+}
+
+// MARK: - Object's mappers
+
+extension Resource where Description == TokenResponseDescription {
+    func toCredentials() -> Credentials {
+        return Credentials(
+            accessToken: self.accessToken,
+            tokenType: self.tokenType,
+            refreshToken: self.refreshToken,
+            validUntil: Date(timeIntervalSince1970: self.createdAt + self.expiresIn)
+        )
+    }
+}
+
+extension Resource where Description == SurveyResponseDescription {
+    func toSurvey() -> Survey {
+        return Survey(
+            id: self.id.rawValue as? String ?? UUID().uuidString,
+            title: self.title,
+            description: self.attributes.description.value,
+            coverImageUrl: self.coverImageUrl
+        )
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -14,6 +14,10 @@ target 'NimbleSurvey' do
   pod 'Alamofire'
   pod 'RxAlamofire'
 
+  # Parsing
+  pod 'Poly', :git => 'https://github.com/mattpolzin/Poly.git'
+  pod 'MP-JSONAPI', :git => 'https://github.com/mattpolzin/JSONAPI.git'
+
   # Secure storage
   pod 'KeychainAccess'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,6 +4,9 @@ PODS:
   - Differentiator (5.0.0)
   - KeychainAccess (4.2.2)
   - Kingfisher (6.3.1)
+  - MP-JSONAPI (5.0.2):
+    - Poly (~> 2.4)
+  - Poly (2.5.3)
   - R.swift (6.1.0):
     - R.swift.Library (~> 5.3.0)
   - R.swift.Library (5.3.0)
@@ -35,6 +38,8 @@ DEPENDENCIES:
   - CHIPageControl/Aji
   - KeychainAccess
   - Kingfisher
+  - MP-JSONAPI (from `https://github.com/mattpolzin/JSONAPI.git`)
+  - Poly (from `https://github.com/mattpolzin/Poly.git`)
   - R.swift
   - RxAlamofire
   - RxBlocking (= 6.5.0)
@@ -66,12 +71,28 @@ SPEC REPOS:
     - SnapKit
     - SwiftLint
 
+EXTERNAL SOURCES:
+  MP-JSONAPI:
+    :git: https://github.com/mattpolzin/JSONAPI.git
+  Poly:
+    :git: https://github.com/mattpolzin/Poly.git
+
+CHECKOUT OPTIONS:
+  MP-JSONAPI:
+    :commit: a72ed5c349567ca6f5254f7e8e59cd555e4711b8
+    :git: https://github.com/mattpolzin/JSONAPI.git
+  Poly:
+    :commit: ec466eb43176afb5bd178f5eb90b4d1773a5f19b
+    :git: https://github.com/mattpolzin/Poly.git
+
 SPEC CHECKSUMS:
   Alamofire: 87bd8c952f9a4454320fce00d9cc3de57bcadaf5
   CHIPageControl: a787bf7205c9b7e7fbfc412be36c5e8636b68f86
   Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Kingfisher: 016c8b653a35add51dd34a3aba36b580041acc74
+  MP-JSONAPI: 8ce0d9a9c38b8b757b076f77f3e39e3d9808ea26
+  Poly: c0335a75c7f50cab2c5cb2f8c0e4fe1ef935f3da
   R.swift: ec98ff71c4ab2f6fd01dd077e5afd15e63a4834c
   R.swift.Library: 0fc583cb55a99e28901299cc451614cad1161962
   RxAlamofire: beb75a1c452d0de225651db4903f5d29d034a620
@@ -85,6 +106,6 @@ SPEC CHECKSUMS:
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
 
-PODFILE CHECKSUM: d77f9ad206a797b83af7aacd6af88ecf705f71e7
+PODFILE CHECKSUM: 8123d488f2643b553d3e22e3e1aa16a179ac3012
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
This PR addresses #24 opened by @minhnimble.

## Discussion

For parsing API responses I don't usually do it manually. I use [online](https://app.quicktype.io) or [Mac utility](https://www.macupdate.com/app/mac/59932/cutebaby) tools to generate temporary data types supporting parsing.

I did check the [recommendation](https://jsonapi.org/implementations/#client-libraries-ios), but with very simple responses I'd rather hand-code the parsing to introduce a 3rd party library with no activity for 3 years.

This time I examine the recommendation list of the iOS libraries more carefully. I chose [JSONAPI](https://github.com/mattpolzin/JSONAPI) since it leverages `Codable` without introducing any dependency like `ABCEncoder` or `XYZSerializer`. It fits well with the existing app's Network layer without breaking/refactoring.